### PR TITLE
update `tracing-subscriber` to 0.2.0 stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 opentelemetry = "0.1.3"
 rand = "0.7.2"
 tracing-core = "0.1.7"
-tracing-subscriber = "0.2.0-alpha.1"
+tracing-subscriber = "0.2.0"
 
 [dev-dependencies]
 tracing = "0.1.10"


### PR DESCRIPTION
`tracing-subscriber` 0.2.0-stable is a major release with several bug
fixes, including fixes for a memory leak in the `Registry` span storage.
Since Cargo cannot automatically update versions ending with `-alpha.X`,
crates depending on earlier `tracing-subscriber` 0.2.0 alpha releases
should update to stable. 

See tokio-rs/tracing#567 for the complete changelog.