### PR TITLE
upgrade crates version and update example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,14 @@ edition = "2018"
 [dependencies]
 opentelemetry = "0.4.0"
 rand = "0.7.3"
-tracing = "0.1.12"
-tracing-core = "0.1.9"
-tracing-subscriber = "0.2.0"
+tracing = "0.1.13"
+tracing-core = "0.1.10"
+tracing-subscriber = "0.2.3"
 
 [dev-dependencies]
 opentelemetry-jaeger = "0.3.0"
 thrift = "0.13.0"
-tracing-attributes = "0.1.6"
+tracing-attributes = "0.1.7"
 
 [workspace]
 members = ["examples/tonic"]

--- a/examples/span_extension.rs
+++ b/examples/span_extension.rs
@@ -5,8 +5,8 @@ use opentelemetry::api::{HttpTextFormat, Provider};
 use opentelemetry::{api, global};
 use std::collections::HashMap;
 use tracing_opentelemetry::{OpenTelemetryLayer, OpenTelemetrySpanExt};
-use tracing_subscriber::{Layer, Registry};
 use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::{Layer, Registry};
 
 fn make_request(_span_context: api::SpanContext) {
     // perform external request after injecting context

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -200,7 +200,9 @@ where
         builder.parent_context = self.parent_context(attrs, &ctx);
 
         // Ensure trace id exists so children are matched properly.
-        if builder.parent_context.is_none() {
+        if let Some(parent_context) = &builder.parent_context {
+            builder.trace_id = Some(parent_context.trace_id());
+        } else {
             builder.trace_id = Some(api::TraceId::from_u128(rand::random()));
         }
 


### PR DESCRIPTION
I use this crate for a project and need to be up to date to not have 2 different versions of tracing. Here is a pull-request to update dependencies. There is a breaking change which force `T::Span` to be `Send` and `Sync`. I also updated the example to force provider to use `sdk::Tracer` and not `BoxedSpan` as before because it's not thread safe.
