### PR TITLE
Remove OpenTelemetry metrics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,12 @@ categories = [
     "development-tools::profiling",
     "asynchronous",
 ]
-keywords = ["tracing", "opentelemetry", "jaeger", "zipkin", "prometheus", "async"]
+keywords = ["tracing", "opentelemetry", "jaeger", "zipkin", "async"]
 license = "MIT"
 edition = "2018"
 
 [dependencies]
-opentelemetry = "0.4.0"
+opentelemetry = { version = "0.4.0", default-features = false, features = ["trace"] }
 rand = "0.7.3"
 tracing = "0.1.12"
 tracing-core = "0.1.9"

--- a/examples/tonic/Cargo.toml
+++ b/examples/tonic/Cargo.toml
@@ -19,7 +19,7 @@ tokio = { version = "0.2", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = "0.2"
 tracing-opentelemetry = { version = "0.2", path = "../.." }
-opentelemetry = "0.4"
+opentelemetry = { version = "0.4", default-features = false, features = ["trace"] }
 opentelemetry-jaeger = "0.3"
 
 [build-dependencies]


### PR DESCRIPTION
This crate does not use any features of `OpenTelemetry` besides tracing, so the additional default features can be removed to decrease the number of dependencies that this crate introduces.