### PR TITLE
Change span status code on error event

### DIFF
--- a/src/layer.rs
+++ b/src/layer.rs
@@ -235,6 +235,10 @@ where
                     ],
                 );
 
+                if builder.status_code.is_none() && *event.metadata().level() == tracing_core::Level::ERROR {
+                    builder.status_code = Some(api::StatusCode::Unknown);
+                }
+
                 event.record(&mut SpanEventVisitor(&mut otel_event));
 
                 if let Some(ref mut events) = builder.message_events {


### PR DESCRIPTION
The span status code changes (if it has not been set previously) on error event. I saw discussion in #17, but i think it's not quite correct to change status code in record_error method because someone (e.g. me)) may want to add error to span as part of trace/debug/info-event without changing span status.